### PR TITLE
21 enhance codebase with explicit type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
+# Webstorm/Intellij project-specific configuration files
+.idea
+DockerFile
+
+# vscode project-specific configuration files
 .vscode
+
+# Local development environment file
 /backend/.env

--- a/backend/src/cli/seed.ts
+++ b/backend/src/cli/seed.ts
@@ -4,7 +4,7 @@ import { ADMIN_EMAIL, ADMIN_PASSWORD } from '../utils/globals';
 
 const dbClient = new PrismaClient();
 
-const main = async () => {
+const main = async (): Promise<void> => {
     const adminData: Prisma.UserCreateInput = {
         email: ADMIN_EMAIL,
         username: 'weblercodes',

--- a/backend/src/exceptions/enums/ErrorCode.ts
+++ b/backend/src/exceptions/enums/ErrorCode.ts
@@ -1,4 +1,4 @@
-export enum ErrorCode {
+export const enum ErrorCode {
     USER_ALREADY_EXISTS = 1001,
     USER_NOT_FOUND = 1002,
     INCORRECT_PASSWORD = 1003,

--- a/backend/src/helpers/authHelper.ts
+++ b/backend/src/helpers/authHelper.ts
@@ -38,7 +38,7 @@ export const generateEmailVerificationCode = async (userId: bigint, username: st
  * @param userId User ID
  * @returns User
  */
-export const getAuthenticatedUser = async (userId: bigint) => {
+export const getAuthenticatedUser= async (userId: bigint) => {
     const user = await dbClient.user.findFirst({ where: { id: userId } });
         
     if(!user || !user.isVerified) {

--- a/backend/src/middleware/errorMiddleware.ts
+++ b/backend/src/middleware/errorMiddleware.ts
@@ -25,7 +25,7 @@ export const errorHandler = (method: Function) => {
     }
 }
 
-export const errorMiddleware = (error: HttpException, req: Request, res: Response, next: NextFunction) => {
+export const errorMiddleware = (error: HttpException, req: Request, res: Response, next: NextFunction): void => {
     res.status(error.statusCode)
         .json({
             message: error.message,

--- a/backend/src/services/email.ts
+++ b/backend/src/services/email.ts
@@ -20,7 +20,7 @@ const mailTransport = nodemailer.createTransport({
  * @param subject Email subject
  * @param html Email content in HTML format
  */
-const sendMail = async (to: string[] | string, subject: string, html: string) => {
+const sendMail = async (to: string[] | string, subject: string, html: string): Promise<void> => {
     const mailOptions = {
         from: `Webler Codes Team <${EMAIL_USER}>`,
         to,

--- a/backend/src/services/logger.ts
+++ b/backend/src/services/logger.ts
@@ -8,7 +8,7 @@ import { generateRandomFileName } from '../utils/fileUtils';
  * 
  * @param content Log file content
  */
-const writeLogFile = (content: any) => {
+const writeLogFile = (content: any): void => {
     let logFileName = `${generateRandomFileName()}.log`;
     let dirPath = path.join(__dirname, '../..', LOG_DIR);
 

--- a/backend/src/utils/globals.ts
+++ b/backend/src/utils/globals.ts
@@ -2,15 +2,15 @@ import { configDotenv } from 'dotenv';
 
 configDotenv();
 
-export const NODE_ENV = process.env.NODE_ENV;
+export const NODE_ENV: undefined_t<string> = process.env.NODE_ENV;
 
 export const BACKEND_PORT = process.env.BACKEND_PORT as unknown as number;
 
-export const EMAIL_HOST = process.env.EMAIL_HOST;
-export const EMAIL_PORT = process.env.EMAIL_PORT as number | undefined;
+export const EMAIL_HOST: undefined_t<string> = process.env.EMAIL_HOST;
+export const EMAIL_PORT: undefined_t<number> = process.env.EMAIL_PORT as number | undefined;
 export const EMAIL_SECURE = process.env.EMAIL_SECURE === "true";
-export const EMAIL_USER = process.env.EMAIL_USER;
-export const EMAIL_PASSWORD = process.env.EMAIL_PASSWORD;
+export const EMAIL_USER: undefined_t<string> = process.env.EMAIL_USER;
+export const EMAIL_PASSWORD: undefined_t<string> = process.env.EMAIL_PASSWORD;
 
 export const API_PREFIX = '/api';
 

--- a/backend/types.d.ts
+++ b/backend/types.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @file types.d.ts
+ * @data  13th june, 2024
+ *
+ * This source file contains all global types defined by the webler group.
+ * Naming Convention:
+ *  =====================
+ *  The name of a type should be in a "camelCase" followed by a _t if the
+ *  definition is an actual type aliasing. for example, a nullable string could be
+ *  defined as
+ *
+ *  type nullableString_t = string | null;
+ *
+ *  As opposed to type aliasing, interface, should be prefix or suffix by a lowercase "i"
+ *
+ *  interface hotGirl_i
+ *  interface iHotty
+ *  interface i_ForkIsNotF&ck
+ *
+ *  Honestly, i would have prefer the "iHotty" syntax. why not just make that the standard bro.
+ */
+
+type undefined_t<T> = T | undefined;


### PR DESCRIPTION
The major change that worth mentioning is the addition of webstorm's ignore files to the project main .gitignore. This will prevent the upload of webstorm's project specific directories and files.

In addition, there is now a `types.d.ts` file in the `/backend/` directory.  This file hold all type definition and aliasing for now and future references. Currently there is just one type definition for undefined types.